### PR TITLE
Allow subclassing of SceneParameters

### DIFF
--- a/test/test_scene_parameters.py
+++ b/test/test_scene_parameters.py
@@ -1,7 +1,25 @@
 """Tests for ``scene_parameters.py``."""
+
+import dataclasses
 import json
 
 from two4two import scene_parameters
+
+
+@dataclasses.dataclass
+class MyParameters(scene_parameters.SceneParameters):
+    """Class to test subclass of SceneParameters."""
+    my_field: str = "my very unique value"
+
+
+def test_subclass_scene_parameters():
+    """Tests if load selects the right subclass."""
+    param = MyParameters()
+    json_buf = json.dumps(param.state_dict())
+    loaded_param = scene_parameters.SceneParameters.load(json.loads(json_buf))
+    assert param == loaded_param
+    assert type(loaded_param) == MyParameters
+    assert loaded_param.my_field == "my very unique value"
 
 
 def test_scene_parameters_loading():
@@ -9,7 +27,7 @@ def test_scene_parameters_loading():
     sampler = scene_parameters.SampleSceneParameters()
     sampled_param = sampler.sample()
     json_buf = json.dumps(sampled_param.state_dict())
-    loaded_param = scene_parameters.SceneParameters(**json.loads(json_buf))
+    loaded_param = scene_parameters.SceneParameters.load(json.loads(json_buf))
     assert sampled_param == loaded_param
 
 

--- a/two4two/_blender/render_samples.py
+++ b/two4two/_blender/render_samples.py
@@ -20,7 +20,7 @@ from two4two.scene_parameters import SceneParameters  # noqa: E402
 def _render_files(param_file: str, save_location: str):
     with open(param_file) as fparam:
         for line in fparam.readlines():
-            params = SceneParameters(**json.loads(line))
+            params = SceneParameters.load(json.loads(line))
             scene = Scene(params)
             image_fname = os.path.join(save_location, params.filename)
             base, ext = os.path.splitext(image_fname)

--- a/two4two/blender.py
+++ b/two4two/blender.py
@@ -54,8 +54,7 @@ def _load_images_from_param_file(
     """
     with open(param_filename) as f:
         for line in f.readlines():
-            params = scene_parameters.SceneParameters(
-                **json.loads(line))
+            params = scene_parameters.SceneParameters.load(json.loads(line))
             img_fname = os.path.join(os.path.dirname(param_filename),
                                      params.filename)
 


### PR DESCRIPTION
`SceneParameters.state_dict` now also saves the class name and the module.
When loading with `SceneParameters.load`, the corresponding class and module is loaded. 
This allows to subclass SceneParameters and add new custom fields, e.g. a new parameter during sampling.